### PR TITLE
deb: fixup wrong resolution in cm.mk

### DIFF
--- a/cm.mk
+++ b/cm.mk
@@ -1,7 +1,7 @@
 
 # Boot animation
 TARGET_SCREEN_HEIGHT := 1920
-TARGET_SCREEN_WIDTH := 1080
+TARGET_SCREEN_WIDTH := 1200
 
 # Inherit some common CM stuff.
 $(call inherit-product, vendor/cm/config/common_full_tablet_wifionly.mk)


### PR DESCRIPTION
looks like the width is wrong.

boot animation size is wrong as mentioned by Greg Willard in
http://review.cyanogenmod.org/#/c/81185/

Change-Id: I096e468bab8ea7992ac034a151011d727d439595
